### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-* @thomasklinger1234
-* @otto-wagner
-* @RamazanKara
-* @stefanschmidt1701
+* @otto-de/shopentrance


### PR DESCRIPTION
aggregate codeowners using the appropriate github team instead individuals. This prevents having to update the `CODEOWNRS` file in the future and helps delegate permissions using GitHub teams. 