### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+We acknowledge that every line of code that we write may potentially contain security issues.
+We are trying to deal with it responsibly and provide patches as quickly as possible. 
+
+If you have found a security related issue, please write to [disclosure](mailto:disclosure@otto.de) 


### PR DESCRIPTION
adds a required file to provide hints for dealing with security disclosures.